### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# CC3/CC4 Blender Tools
-An add-on for importing and automatically setting up materials for Character Creator 3 & 4 character exports.
+# CC/iC Blender Tools
+An add-on for importing and automatically setting up materials for Character Creator 3 & 4 and iClone 7 & 8 character exports.
 
 Using Blender in the Character Creator pipeline can often feel like hitting a brick wall. Spending potentially hours having to get the import settings correct and setting up the materials often with hundreds of textures.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Links
 ## Changelog
 
 ### 1.3.6
+- Rigify
+    - Finger roll alignment fixed.
 - Physics:
     - PhysX weight maps normalized, provides a more consistent and controllable simulation for different weight maps.
     - Tweaked cloth simulation parameters.

--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ Links
 
 ### 1.3.6
 - Rigify
-    - Finger roll alignment fixed.
+    - Finger roll alignment fixed. All fingers now have exactly the same local bend axis.
 - Physics:
-    - PhysX weight maps normalized, provides a more consistent and controllable simulation for different weight maps.
-    - Tweaked cloth simulation parameters.
+    - Low poly (1/8th) Collision Body mesh created from decimating a copy of the Body mesh and removing the eyelashes.
+        - Hair would easily get trapped in the eyelashes and a lower poly collision mesh should speed up the cloth simulation.
+    - PhysX weight maps normalized, provides a more consistent and controllable simulation across different weight maps.
+    - Tweaked some cloth simulation parameters.
     - Smart Hair meshes in particular should simulate better now.
 
 ### 1.3.5

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-# CC3 Blender Tools
-An add-on for importing and automatically setting up materials for Character Creator 3 character exports.
+# CC3/CC4 Blender Tools
+An add-on for importing and automatically setting up materials for Character Creator 3 & 4 character exports.
 
-Using Blender in the Character Creator 3 pipeline can often feel like hitting a brick wall. Spending potentially hours having to get the import settings correct and setting up the materials often with hundreds of textures.
+Using Blender in the Character Creator pipeline can often feel like hitting a brick wall. Spending potentially hours having to get the import settings correct and setting up the materials often with hundreds of textures.
 
 This add-on aims to reduce that time spent getting characters into Blender down to just a few seconds and make use of as many of the exported textures as possible so that character artists can work in the highest quality possible using Blender.
 
-[Online Documentation](https://soupday.github.io/cc3_blender_tools/index.html) (Work in progress...)
+[Online Documentation](https://soupday.github.io/cc3_blender_tools/index.html)
 
 [Reallusion Forum Thread](https://forum.reallusion.com/475005/Blender-Auto-Setup)
 
 Links
 =====
 [CC3 Round-trip Import Plugin](https://github.com/soupday/CC3-Blender-Tools-Plugin)
+[CC4 Round-trip Import Plugin](https://github.com/soupday/CC4-Blender-Tools-Plugin)
 [Baking Add-on](https://github.com/soupday/cc3_blender_bake)
 
 ## Installation, Updating, Removal
@@ -41,6 +42,8 @@ Links
     - PhysX weight maps normalized, provides a more consistent and controllable simulation across different weight maps.
     - Tweaked some cloth simulation parameters.
     - Smart Hair meshes in particular should simulate better now.
+- Unity:
+    - Added animation export options (Actions or Strips)
 
 ### 1.3.5
 - Fix to shape-key action name matching.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Links
 
 ## Changelog
 
+### 1.3.6
+- Physics:
+    - PhysX weight maps normalized, provides a more consistent and controllable simulation for different weight maps.
+    - Tweaked cloth simulation parameters.
+    - Smart Hair meshes in particular should simulate better now.
+
 ### 1.3.5
 - Fix to shape-key action name matching.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ This add-on aims to reduce that time spent getting characters into Blender down 
 Links
 =====
 [CC3 Round-trip Import Plugin](https://github.com/soupday/CC3-Blender-Tools-Plugin)
+
 [CC4 Round-trip Import Plugin](https://github.com/soupday/CC4-Blender-Tools-Plugin)
+
 [Baking Add-on](https://github.com/soupday/cc3_blender_bake)
 
 ## Installation, Updating, Removal

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Links
 ### 1.3.6
 - Rigify
     - Finger roll alignment fixed. All fingers now have exactly the same local bend axis.
+    - Disables all physics modifiers non-contributing armatures and meshes during retarget baking to speed it up a bit.
 - Physics:
     - Low poly (1/8th) Collision Body mesh created from decimating a copy of the Body mesh and removing the eyelashes.
         - Hair would easily get trapped in the eyelashes and a lower poly collision mesh should speed up the cloth simulation.

--- a/__init__.py
+++ b/__init__.py
@@ -76,7 +76,7 @@ from . import rigging
 bl_info = {
     "name": "CC3 Tools",
     "author": "Victor Soupday",
-    "version": (1, 3, 5),
+    "version": (1, 3, 6),
     "blender": (2, 80, 0),
     "category": "Characters",
     "location": "3D View > Properties> CC3",

--- a/bones.py
+++ b/bones.py
@@ -441,11 +441,12 @@ def clear_constraints(rig, pose_bone_name):
 
 def clear_drivers(rig):
     drivers = rig.animation_data.drivers
-    fcurves = []
-    for fc in drivers:
-        fcurves.append(fc)
-    for fc in fcurves:
-        drivers.remove(fc)
+    if drivers:
+        fcurves = []
+        for fc in drivers:
+            fcurves.append(fc)
+        for fc in fcurves:
+            drivers.remove(fc)
 
 
 def get_bone_name_from_data_path(data_path):

--- a/exporter.py
+++ b/exporter.py
@@ -44,7 +44,7 @@ def check_valid_export_fbx(chr_cache, objects):
 
         obj : bpy.types.Object
         for obj in objects:
-            if obj != arm and utils.object_exists_in_scenes(obj):
+            if obj != arm and utils.object_exists(obj):
                 if obj.type != "MESH":
                     message = f"ERROR: Object: {obj.name} is not a mesh!"
                     report.append(message)
@@ -220,66 +220,64 @@ def prep_export_cc3(chr_cache, new_name, objects, json_data, old_path, new_path)
             obj_json = copy.deepcopy(params.JSON_MESH_DATA)
             chr_json["Meshes"][obj_source_name] = obj_json
 
-        if obj_json and utils.still_exists(obj):
+        if obj_json and utils.object_exists_is_mesh(obj):
 
-            if obj.type == "MESH":
+            for slot in obj.material_slots:
+                mat = slot.material
+                mat_name = mat.name
+                mat_source_name = utils.strip_name(mat.name)
+                mat_json = jsonutils.get_material_json(obj_json, mat)
+                mat_cache = chr_cache.get_material_cache(mat)
 
-                for slot in obj.material_slots:
-                    mat = slot.material
-                    mat_name = mat.name
-                    mat_source_name = utils.strip_name(mat.name)
-                    mat_json = jsonutils.get_material_json(obj_json, mat)
-                    mat_cache = chr_cache.get_material_cache(mat)
+                # if the name has been changed since it was cached, change it in the json
+                cache_source_name = None
+                if mat_cache:
+                    cache_source_name = mat_cache.source_name
+                if not cache_source_name:
+                    cache_source_name = mat_source_name
+                if mat_source_name != cache_source_name:
+                    new_mat_name = mat_name.replace('.', '_')
+                    if cache_source_name in obj_json["Materials"].keys():
+                        utils.log_info(f"Updating material json name: {cache_source_name} to {new_mat_name}")
+                        obj_json["Materials"][new_mat_name] = obj_json["Materials"].pop(cache_source_name)
+                    changes.append(["MATERIAL_RENAME", mat, mat.name])
+                    mat.name = new_mat_name
+                    mat_name = new_mat_name
+                    mat_source_name = new_mat_name
 
-                    # if the name has been changed since it was cached, change it in the json
-                    cache_source_name = None
-                    if mat_cache:
-                        cache_source_name = mat_cache.source_name
-                    if not cache_source_name:
-                        cache_source_name = mat_source_name
-                    if mat_source_name != cache_source_name:
-                        new_mat_name = mat_name.replace('.', '_')
-                        if cache_source_name in obj_json["Materials"].keys():
-                            utils.log_info(f"Updating material json name: {cache_source_name} to {new_mat_name}")
-                            obj_json["Materials"][new_mat_name] = obj_json["Materials"].pop(cache_source_name)
-                        changes.append(["MATERIAL_RENAME", mat, mat.name])
-                        mat.name = new_mat_name
-                        mat_name = new_mat_name
-                        mat_source_name = new_mat_name
-
-                    if mat_cache:
-                        if mat_cache.user_added:
-                            # add new material json data if user added
-                            mat_json = copy.deepcopy(params.JSON_PBR_MATERIAL)
-                            obj_json["Materials"][mat_source_name] = mat_json
-                        if prefs.export_json_changes:
-                            write_back_json(mat_json, mat, mat_cache)
-                        if prefs.export_texture_changes:
-                            write_back_textures(mat_json, mat, mat_cache, old_path, chr_cache.import_name, True)
-                    if mat_json:
-                        # replace duplicate materials with a reference to a single source material
-                        # (this is to ensure there are no duplicate suffixes in the fbx export)
-                        if mat_count[mat_source_name] > 1:
-                            new_mat = mat_remap[mat_source_name]
-                            slot.material = new_mat
-                            utils.log_info("Replacing material: " + mat.name + " with " + new_mat.name)
-                            changes.append(["MATERIAL_SLOT_REPLACE", slot, mat])
-                            mat = new_mat
-                            mat_name = new_mat.name
-                        # strip any blender numerical suffixes
-                        if mat_name != mat_source_name:
-                            utils.log_info(f"Reverting material name: {mat_name} to {mat_source_name}")
-                            mat.name = mat_source_name
-                            changes.append(["MATERIAL_RENAME", mat, mat_name])
-                        # when saving the export to a new location, the texture paths need to point back to the
-                        # original texture locations, either by new relative paths or absolute paths
-                        # pbr textures:
-                        for channel in mat_json["Textures"].keys():
-                            remap_texture_path(mat_json["Textures"][channel], old_path, new_path)
-                        # custom shader textures:
-                        if "Custom Shader" in mat_json.keys():
-                            for channel in mat_json["Custom Shader"]["Image"].keys():
-                                remap_texture_path(mat_json["Custom Shader"]["Image"][channel], old_path, new_path)
+                if mat_cache:
+                    if mat_cache.user_added:
+                        # add new material json data if user added
+                        mat_json = copy.deepcopy(params.JSON_PBR_MATERIAL)
+                        obj_json["Materials"][mat_source_name] = mat_json
+                    if prefs.export_json_changes:
+                        write_back_json(mat_json, mat, mat_cache)
+                    if prefs.export_texture_changes:
+                        write_back_textures(mat_json, mat, mat_cache, old_path, chr_cache.import_name, True)
+                if mat_json:
+                    # replace duplicate materials with a reference to a single source material
+                    # (this is to ensure there are no duplicate suffixes in the fbx export)
+                    if mat_count[mat_source_name] > 1:
+                        new_mat = mat_remap[mat_source_name]
+                        slot.material = new_mat
+                        utils.log_info("Replacing material: " + mat.name + " with " + new_mat.name)
+                        changes.append(["MATERIAL_SLOT_REPLACE", slot, mat])
+                        mat = new_mat
+                        mat_name = new_mat.name
+                    # strip any blender numerical suffixes
+                    if mat_name != mat_source_name:
+                        utils.log_info(f"Reverting material name: {mat_name} to {mat_source_name}")
+                        mat.name = mat_source_name
+                        changes.append(["MATERIAL_RENAME", mat, mat_name])
+                    # when saving the export to a new location, the texture paths need to point back to the
+                    # original texture locations, either by new relative paths or absolute paths
+                    # pbr textures:
+                    for channel in mat_json["Textures"].keys():
+                        remap_texture_path(mat_json["Textures"][channel], old_path, new_path)
+                    # custom shader textures:
+                    if "Custom Shader" in mat_json.keys():
+                        for channel in mat_json["Custom Shader"]["Image"].keys():
+                            remap_texture_path(mat_json["Custom Shader"]["Image"][channel], old_path, new_path)
 
         if prefs.export_bone_roll_fix:
             if obj.type == "ARMATURE":
@@ -377,66 +375,64 @@ def prep_export_unity(chr_cache, new_name, objects, json_data, old_path, new_pat
             obj_json = copy.deepcopy(params.JSON_MESH_DATA)
             chr_json["Meshes"][obj_source_name] = obj_json
 
-        if obj_json and utils.still_exists(obj):
+        if obj_json and utils.object_exists_is_mesh(obj):
 
-            if obj.type == "MESH":
+            for slot in obj.material_slots:
+                mat = slot.material
+                mat_name = mat.name
+                mat_source_name = utils.strip_name(mat.name)
+                mat_cache = chr_cache.get_material_cache(mat)
 
-                for slot in obj.material_slots:
-                    mat = slot.material
-                    mat_name = mat.name
-                    mat_source_name = utils.strip_name(mat.name)
-                    mat_cache = chr_cache.get_material_cache(mat)
+                # if the name has been changed since it was cached, change it in the json
+                cache_source_name = None
+                if mat_cache:
+                    cache_source_name = mat_cache.source_name
+                if not cache_source_name:
+                    cache_source_name = mat_source_name
+                if mat_source_name != cache_source_name:
+                    new_mat_name = mat_name.replace('.', '_')
+                    if cache_source_name in obj_json["Materials"].keys():
+                        utils.log_info(f"Updating material json name: {cache_source_name} to {new_mat_name}")
+                        obj_json["Materials"][new_mat_name] = obj_json["Materials"].pop(cache_source_name)
+                    changes.append(["MATERIAL_RENAME", mat, mat.name])
+                    mat.name = new_mat_name
+                    mat_name = new_mat_name
+                    mat_source_name = new_mat_name
 
-                    # if the name has been changed since it was cached, change it in the json
-                    cache_source_name = None
-                    if mat_cache:
-                        cache_source_name = mat_cache.source_name
-                    if not cache_source_name:
-                        cache_source_name = mat_source_name
-                    if mat_source_name != cache_source_name:
-                        new_mat_name = mat_name.replace('.', '_')
-                        if cache_source_name in obj_json["Materials"].keys():
-                            utils.log_info(f"Updating material json name: {cache_source_name} to {new_mat_name}")
-                            obj_json["Materials"][new_mat_name] = obj_json["Materials"].pop(cache_source_name)
-                        changes.append(["MATERIAL_RENAME", mat, mat.name])
-                        mat.name = new_mat_name
-                        mat_name = new_mat_name
-                        mat_source_name = new_mat_name
-
-                    # if the material name has duplicate suffix, generate a new name and
-                    # update the json with the new name:
-                    if mat_name != mat_source_name:
-                        utils.log_info(f"Removing blender duplication suffix from material: {mat_name}")
-                        new_mat_name = utils.make_unique_name(mat_source_name, bpy.data.materials.keys())
-                        if mat_source_name in obj_json["Materials"].keys():
-                            utils.log_info(f"Updating material json name: {mat_source_name} to {new_mat_name}")
-                            obj_json["Materials"][new_mat_name] = obj_json["Materials"].pop(mat_source_name)
-                        mat.name = new_mat_name
-                        mat_name = new_mat_name
-                        mat_source_name = new_mat_name
-                    mat_json = None
-                    if mat_name in obj_json["Materials"]:
-                        mat_json = obj_json["Materials"][mat_name]
-                    # update the json parameters with any changes
-                    if mat_cache:
-                        if mat_cache.user_added:
-                            # add new material json data if user added
-                            mat_json = copy.deepcopy(params.JSON_PBR_MATERIAL)
-                            obj_json["Materials"][mat_source_name] = mat_json
-                        if prefs.export_json_changes:
-                            write_back_json(mat_json, mat, mat_cache)
-                        if prefs.export_texture_changes:
-                            write_back_textures(mat_json, mat, mat_cache, old_path, chr_cache.import_name, True)
-                    if mat_json:
-                        # when saving the export to a new location, the texture paths need to point back to the
-                        # original texture locations, either by new relative paths or absolute paths
-                        # pbr textures:
-                        for channel in mat_json["Textures"].keys():
-                            update_texture_path(mat_json["Textures"][channel], old_path, new_path, chr_cache.import_name, new_name, as_blend_file, mat_name)
-                        # custom shader textures:
-                        if "Custom Shader" in mat_json.keys():
-                            for channel in mat_json["Custom Shader"]["Image"].keys():
-                                update_texture_path(mat_json["Custom Shader"]["Image"][channel], old_path, new_path, chr_cache.import_name, new_name, as_blend_file, mat_name)
+                # if the material name has duplicate suffix, generate a new name and
+                # update the json with the new name:
+                if mat_name != mat_source_name:
+                    utils.log_info(f"Removing blender duplication suffix from material: {mat_name}")
+                    new_mat_name = utils.make_unique_name(mat_source_name, bpy.data.materials.keys())
+                    if mat_source_name in obj_json["Materials"].keys():
+                        utils.log_info(f"Updating material json name: {mat_source_name} to {new_mat_name}")
+                        obj_json["Materials"][new_mat_name] = obj_json["Materials"].pop(mat_source_name)
+                    mat.name = new_mat_name
+                    mat_name = new_mat_name
+                    mat_source_name = new_mat_name
+                mat_json = None
+                if mat_name in obj_json["Materials"]:
+                    mat_json = obj_json["Materials"][mat_name]
+                # update the json parameters with any changes
+                if mat_cache:
+                    if mat_cache.user_added:
+                        # add new material json data if user added
+                        mat_json = copy.deepcopy(params.JSON_PBR_MATERIAL)
+                        obj_json["Materials"][mat_source_name] = mat_json
+                    if prefs.export_json_changes:
+                        write_back_json(mat_json, mat, mat_cache)
+                    if prefs.export_texture_changes:
+                        write_back_textures(mat_json, mat, mat_cache, old_path, chr_cache.import_name, True)
+                if mat_json:
+                    # when saving the export to a new location, the texture paths need to point back to the
+                    # original texture locations, either by new relative paths or absolute paths
+                    # pbr textures:
+                    for channel in mat_json["Textures"].keys():
+                        update_texture_path(mat_json["Textures"][channel], old_path, new_path, chr_cache.import_name, new_name, as_blend_file, mat_name)
+                    # custom shader textures:
+                    if "Custom Shader" in mat_json.keys():
+                        for channel in mat_json["Custom Shader"]["Image"].keys():
+                            update_texture_path(mat_json["Custom Shader"]["Image"][channel], old_path, new_path, chr_cache.import_name, new_name, as_blend_file, mat_name)
 
     # as the baking system can deselect everything, reselect the export objects here.
     utils.try_select_objects(objects, True)
@@ -729,50 +725,47 @@ def unpack_embedded_textures(chr_cache, chr_json, objects, old_path):
     for obj in objects:
         obj_json = jsonutils.get_object_json(chr_json, obj)
 
-        if obj_json and utils.still_exists(obj):
+        if obj_json and utils.object_exists_is_mesh(obj):
 
-            if obj.type == "MESH":
+            for slot in obj.material_slots:
+                mat = slot.material
+                mat_json = jsonutils.get_material_json(obj_json, mat)
+                mat_cache = chr_cache.get_material_cache(mat)
+                if mat_cache and mat_json:
+                    for tex_mapping in mat_cache.texture_mappings:
+                        image : bpy.types.Image = tex_mapping.image
 
-                for slot in obj.material_slots:
-                    mat = slot.material
-                    mat_json = jsonutils.get_material_json(obj_json, mat)
-                    mat_cache = chr_cache.get_material_cache(mat)
-                    if mat_cache and mat_json:
-                        for tex_mapping in mat_cache.texture_mappings:
-                            image : bpy.types.Image = tex_mapping.image
+                        if image:
+                            try_unpack_image(image, fbm_folder)
+                            image_path = bpy.path.abspath(image.filepath)
 
-                            if image:
-                                try_unpack_image(image, fbm_folder)
-                                image_path = bpy.path.abspath(image.filepath)
+                            # fix the texture json data path:
+                            try:
+                                tex_type = tex_mapping.texture_type
+                                tex_id = params.get_texture_json_id(tex_type)
+                                if tex_id in mat_json["Textures"]:
+                                    tex_info = mat_json["Textures"][tex_id]
 
-                                # fix the texture json data path:
-                                try:
-                                    tex_type = tex_mapping.texture_type
-                                    tex_id = params.get_texture_json_id(tex_type)
-                                    if tex_id in mat_json["Textures"]:
-                                        tex_info = mat_json["Textures"][tex_id]
+                                    # the fbx importer will assign the diffuse alpha to the opacity channel, even if
+                                    # there is an opacity texture present.
+                                    # this means it will incorrectly set the opacity with the diffuse
+                                    # though this will be corrected later by the texture write back,
+                                    # if no write back this will be wrong, so remove the opacity Json data
+                                    if not prefs.export_texture_changes:
+                                        dir, name = os.path.split(image_path)
+                                        if "_Diffuse" in name and tex_type == "ALPHA":
+                                            utils.log_info(f"Diffuse connected to Alpha, removing Opacity data from Json.")
+                                            del mat_json["Textures"][tex_id]
+                                            tex_info = None
 
-                                        # the fbx importer will assign the diffuse alpha to the opacity channel, even if
-                                        # there is an opacity texture present.
-                                        # this means it will incorrectly set the opacity with the diffuse
-                                        # though this will be corrected later by the texture write back,
-                                        # if no write back this will be wrong, so remove the opacity Json data
-                                        if not prefs.export_texture_changes:
-                                            dir, name = os.path.split(image_path)
-                                            if "_Diffuse" in name and tex_type == "ALPHA":
-                                                utils.log_info(f"Diffuse connected to Alpha, removing Opacity data from Json.")
-                                                del mat_json["Textures"][tex_id]
-                                                tex_info = None
-
-                                        if tex_info:
-                                            tex_path = os.path.join(old_path, tex_info["Texture Path"])
-                                            if not utils.is_same_path(tex_path, image_path):
-                                                rel_path = os.path.normpath(utils.relpath(image_path, old_path))
-                                                tex_info["Texture Path"] = rel_path
-                                                utils.log_info(f"Updating embedded image Json data: {rel_path}")
-                                except:
-                                    utils.log_warn(f"Unable to update embedded image Json: {image.name}")
-
+                                    if tex_info:
+                                        tex_path = os.path.join(old_path, tex_info["Texture Path"])
+                                        if not utils.is_same_path(tex_path, image_path):
+                                            rel_path = os.path.normpath(utils.relpath(image_path, old_path))
+                                            tex_info["Texture Path"] = rel_path
+                                            utils.log_info(f"Updating embedded image Json data: {rel_path}")
+                            except:
+                                utils.log_warn(f"Unable to update embedded image Json: {image.name}")
 
 
 def get_export_objects(chr_cache, include_selected = True):
@@ -783,7 +776,7 @@ def get_export_objects(chr_cache, include_selected = True):
     arm = chr_cache.get_armature()
     if arm:
         for obj_cache in chr_cache.object_cache:
-            if utils.object_exists_in_scenes(obj_cache.object):
+            if utils.object_exists(obj_cache.object):
                 if obj_cache.object.type == "ARMATURE":
                     obj_cache.object.hide_set(False)
                     if obj_cache.object not in objects:

--- a/exporter.py
+++ b/exporter.py
@@ -995,9 +995,13 @@ class CC3Export(bpy.types.Operator):
 
             if type == ".fbx":
                 # export as fbx
+                export_actions = prefs.export_animation_mode == "ACTIONS" or prefs.export_animation_mode == "BOTH"
+                export_strips = prefs.export_animation_mode == "STRIPS" or prefs.export_animation_mode == "BOTH"
                 bpy.ops.export_scene.fbx(filepath=self.filepath,
                         use_selection = True,
                         bake_anim = export_anim,
+                        bake_anim_use_all_actions=export_actions,
+                        bake_anim_use_nla_strips=export_strips,
                         use_armature_deform_only=True,
                         add_leaf_bones = False,
                         use_mesh_modifiers = True)
@@ -1084,9 +1088,14 @@ class CC3Export(bpy.types.Operator):
 
             if type == ".fbx":
                 # export as fbx
+                export_actions = prefs.export_animation_mode == "ACTIONS" or prefs.export_animation_mode == "BOTH"
+                export_strips = prefs.export_animation_mode == "STRIPS" or prefs.export_animation_mode == "BOTH"
                 bpy.ops.export_scene.fbx(filepath=props.unity_file_path,
                         use_selection = True,
                         bake_anim = export_anim,
+                        bake_anim_use_all_actions=export_actions,
+                        bake_anim_use_nla_strips=export_strips,
+                        use_armature_deform_only=True,
                         add_leaf_bones = False,
                         use_mesh_modifiers = True)
 

--- a/importer.py
+++ b/importer.py
@@ -169,9 +169,6 @@ def process_object(chr_cache, obj, objects_processed, character_json):
     obj_cache = chr_cache.get_object_cache(obj)
 
     if obj.type == "MESH":
-        # when rebuilding materials remove all the physics modifiers
-        # they don't seem to like having their settings changed...
-        physics.remove_all_physics_mods(obj)
 
         # remove any modifiers for refractive eyes
         modifiers.remove_eye_modifiers(obj)
@@ -183,18 +180,8 @@ def process_object(chr_cache, obj, objects_processed, character_json):
                 utils.log_info("Processing Material: " + mat.name)
                 utils.log_indent()
                 process_material(chr_cache, obj, mat, object_json)
-                if prefs.physics == "ENABLED" and props.physics_mode == "ON":
-                    physics.add_material_weight_map(chr_cache, obj, mat, create = False)
                 utils.log_recess()
                 objects_processed.append(mat)
-
-        # setup default physics
-        if prefs.physics == "ENABLED" and props.physics_mode == "ON":
-            physics.add_collision_physics(chr_cache, obj, obj_cache)
-            edit_mods, mix_mods = modifiers.get_weight_map_mods(obj)
-            if len(edit_mods) + len(mix_mods) > 0:
-                physics.enable_cloth_physics(chr_cache, obj, False)
-                #physics.remap_physx_weight_maps(obj)
 
         # setup special modifiers for displacement, UV warp, etc...
         if chr_cache.setup_mode == "ADVANCED":
@@ -204,7 +191,6 @@ def process_object(chr_cache, obj, objects_processed, character_json):
                 modifiers.add_eye_occlusion_modifiers(obj)
             elif obj_cache.is_tearline():
                 modifiers.add_tearline_modifiers(obj)
-
 
     elif obj.type == "ARMATURE":
 
@@ -686,6 +672,11 @@ class CC3Import(bpy.types.Operator):
                     if cache.object and cache.object in bpy.context.selected_objects:
                         process_object(chr_cache, cache.object, objects_processed, chr_json)
 
+            # setup default physics
+            if prefs.physics == "ENABLED" and props.physics_mode == "ON":
+                physics.add_all_physics(chr_cache)
+
+            # enable SSR
             if prefs.refractive_eyes == "SSR":
                 bpy.context.scene.eevee.use_ssr = True
                 bpy.context.scene.eevee.use_ssr_refraction = True

--- a/importer.py
+++ b/importer.py
@@ -192,8 +192,9 @@ def process_object(chr_cache, obj, objects_processed, character_json):
         if prefs.physics == "ENABLED" and props.physics_mode == "ON":
             physics.add_collision_physics(obj)
             edit_mods, mix_mods = modifiers.get_weight_map_mods(obj)
-            if len(edit_mods) > 0:
-                physics.enable_cloth_physics(obj)
+            if len(edit_mods) + len(mix_mods) > 0:
+                physics.enable_cloth_physics(obj, False)
+                #physics.remap_physx_weight_maps(obj)
 
         # setup special modifiers for displacement, UV warp, etc...
         if chr_cache.setup_mode == "ADVANCED":

--- a/importer.py
+++ b/importer.py
@@ -184,16 +184,16 @@ def process_object(chr_cache, obj, objects_processed, character_json):
                 utils.log_indent()
                 process_material(chr_cache, obj, mat, object_json)
                 if prefs.physics == "ENABLED" and props.physics_mode == "ON":
-                    physics.add_material_weight_map(obj, mat, create = False)
+                    physics.add_material_weight_map(chr_cache, obj, mat, create = False)
                 utils.log_recess()
                 objects_processed.append(mat)
 
         # setup default physics
         if prefs.physics == "ENABLED" and props.physics_mode == "ON":
-            physics.add_collision_physics(obj)
+            physics.add_collision_physics(chr_cache, obj, obj_cache)
             edit_mods, mix_mods = modifiers.get_weight_map_mods(obj)
             if len(edit_mods) + len(mix_mods) > 0:
-                physics.enable_cloth_physics(obj, False)
+                physics.enable_cloth_physics(chr_cache, obj, False)
                 #physics.remap_physx_weight_maps(obj)
 
         # setup special modifiers for displacement, UV warp, etc...

--- a/importer.py
+++ b/importer.py
@@ -674,6 +674,7 @@ class CC3Import(bpy.types.Operator):
 
             # setup default physics
             if prefs.physics == "ENABLED" and props.physics_mode == "ON":
+                utils.log_info("")
                 physics.add_all_physics(chr_cache)
 
             # enable SSR

--- a/materials.py
+++ b/materials.py
@@ -664,6 +664,24 @@ def test_for_material_uv_coords(obj, mat_slot, uvs):
     return False
 
 
+def get_material_slot_by_type(chr_cache, obj, material_type):
+    if obj.type == "MESH":
+        for slot in obj.material_slots:
+            mat = slot.material
+            mat_cache = chr_cache.get_material_cache(mat)
+            if mat_cache and mat_cache.material_type == material_type:
+                return slot.index
+    return -1
+
+
+def get_material_by_type(chr_cache, obj, material_type):
+    if obj.type == "MESH":
+        for mat in obj.data.materials:
+            mat_cache = chr_cache.get_material_cache(mat)
+            if mat_cache and mat_cache.material_type == material_type:
+                return mat
+    return None
+
 
 def reconstruct_obj_materials(obj):
     mesh = obj.data

--- a/meshutils.py
+++ b/meshutils.py
@@ -168,16 +168,46 @@ def generate_eye_vertex_groups(obj, mat_left, mat_right, cache_left, cache_right
                 vertex_group_r.add([vertex.index], weight, 'REPLACE')
 
 
+def get_material_vertex_indices(obj, mat):
+    vert_indices = []
+    mesh = obj.data
+    for poly in mesh.polygons:
+        poly_mat = obj.material_slots[poly.material_index].material
+        if poly_mat == mat:
+            for vert_index in poly.vertices:
+                if vert_index not in vert_indices:
+                    vert_indices.append(vert_index)
+    return vert_indices
+
+
 def get_material_vertices(obj, mat):
     verts = []
     mesh = obj.data
     for poly in mesh.polygons:
         poly_mat = obj.material_slots[poly.material_index].material
         if poly_mat == mat:
-            for vert in poly.vertices:
-                if vert not in verts:
-                    verts.append(vert)
+            for vert_index in poly.vertices:
+                if vert_index not in verts:
+                    verts.append(mesh.vertices[vert_index])
     return verts
+
+
+def remove_material_verts(obj, mat):
+    mesh = obj.data
+    utils.clear_selected_objects()
+    if utils.edit_mode_to(obj):
+        bpy.ops.mesh.select_all(action="DESELECT")
+    if utils.object_mode_to(obj):
+        for vert in mesh.vertices:
+            vert.select = False
+        for poly in mesh.polygons:
+            poly_mat = obj.material_slots[poly.material_index].material
+            if poly_mat == mat:
+                for vert_index in poly.vertices:
+                    mesh.vertices[vert_index].select = True
+    if utils.edit_mode_to(obj):
+        bpy.ops.mesh.delete(type='VERT')
+    utils.object_mode_to(obj)
 
 
 def find_shape_key(obj : bpy.types.Object, shape_key_name):

--- a/modifiers.py
+++ b/modifiers.py
@@ -134,8 +134,8 @@ def get_weight_map_mods(obj):
 def get_material_weight_map_mods(obj, mat):
     edit_mod = None
     mix_mod = None
-    mat_name = utils.strip_name(mat.name)
     if obj is not None and mat is not None:
+        mat_name = utils.strip_name(mat.name)
         for mod in obj.modifiers:
             if mod.type == "VERTEX_WEIGHT_EDIT" and (vars.NODE_PREFIX + mat_name + "_WeightEdit") in mod.name:
                 edit_mod = mod

--- a/modifiers.py
+++ b/modifiers.py
@@ -102,11 +102,20 @@ def get_cloth_physics_mod(obj):
     return None
 
 
-def get_collision_physics_mod(obj):
+def get_collision_physics_mod(chr_cache, obj):
+    obj_cache = chr_cache.get_object_cache(obj)
     if obj is not None:
         for mod in obj.modifiers:
             if mod.type == "COLLISION":
                 return mod
+        if obj_cache and obj_cache.object_type == "BODY":
+            if chr_cache.collision_body:
+                try:
+                    for mod in chr_cache.collision_body.modifiers:
+                        if mod.type == "COLLISION":
+                            return mod
+                except:
+                    pass
     return None
 
 
@@ -125,11 +134,12 @@ def get_weight_map_mods(obj):
 def get_material_weight_map_mods(obj, mat):
     edit_mod = None
     mix_mod = None
+    mat_name = utils.strip_name(mat.name)
     if obj is not None and mat is not None:
         for mod in obj.modifiers:
-            if mod.type == "VERTEX_WEIGHT_EDIT" and (vars.NODE_PREFIX + mat.name + "_WeightEdit") in mod.name:
+            if mod.type == "VERTEX_WEIGHT_EDIT" and (vars.NODE_PREFIX + mat_name + "_WeightEdit") in mod.name:
                 edit_mod = mod
-            if mod.type == "VERTEX_WEIGHT_MIX" and (vars.NODE_PREFIX + mat.name + "_WeightMix") in mod.name:
+            if mod.type == "VERTEX_WEIGHT_MIX" and (vars.NODE_PREFIX + mat_name + "_WeightMix") in mod.name:
                 mix_mod = mod
     return edit_mod, mix_mod
 
@@ -294,6 +304,17 @@ def add_tearline_modifiers(obj):
         move_mod_first(obj, displace_mod_all_r)
 
     utils.log_info("Tearline Displacement modifiers applied to: " + obj.name)
+
+
+def add_decimate_modifier(obj, ratio):
+    mod : bpy.types.DecimateModifier
+    mod = get_object_modifier(obj, "DECIMATE", "Decimate_Collision_Body")
+    if not mod:
+        mod = obj.modifiers.new(utils.unique_name("Decimate_Collision_Body"), "DECIMATE")
+    print("#################", mod)
+    mod.decimate_type = 'COLLAPSE'
+    mod.ratio = ratio
+    return mod
 
 
 def has_modifier(obj, modifier_type):

--- a/modifiers.py
+++ b/modifiers.py
@@ -311,7 +311,6 @@ def add_decimate_modifier(obj, ratio):
     mod = get_object_modifier(obj, "DECIMATE", "Decimate_Collision_Body")
     if not mod:
         mod = obj.modifiers.new(utils.unique_name("Decimate_Collision_Body"), "DECIMATE")
-    print("#################", mod)
     mod.decimate_type = 'COLLAPSE'
     mod.ratio = ratio
     return mod

--- a/panels.py
+++ b/panels.py
@@ -1309,6 +1309,13 @@ class CC3ToolsPhysicsPanel(bpy.types.Panel):
             op = col_2.operator("cc3.setphysics", icon="ERROR", text="Delete")
             op.param = "PHYSICS_DELETE"
 
+        if chr_cache:
+            layout.box().label(text="Character Setting", icon="FORCE_CURVE")
+            if chr_cache.physics_disabled:
+                layout.row().operator("cc3.setphysics", icon="PLAY", text="Enable Physics").param = "ENABLE_PHYSICS"
+            else:
+                layout.row().operator("cc3.setphysics", icon="PAUSE", text="Disable Physics").param = "DISABLE_PHYSICS"
+
 
 class CC3ToolsPipelinePanel(bpy.types.Panel):
     bl_idname = "CC3_PT_Pipeline_Panel"

--- a/panels.py
+++ b/panels.py
@@ -1034,10 +1034,13 @@ class CC3RigifyPanel(bpy.types.Panel):
                         op = row.operator("cc3.exporter", icon="CUBE", text="Export To Unity")
                         op.param = "EXPORT_UNITY"
                         row2 = layout.row()
-                        row2.label(text="Rigged character FBX only", icon="INFO")
+                        row2.prop(prefs, "export_animation_mode", expand=True)
+                        row3 = layout.row()
+                        row3.label(text="Rigged character FBX only", icon="INFO")
                         if not chr_cache:
                             row.enabled = False
                             row2.enabled = False
+                            row3.enabled = False
 
             else:
                 wrapped_text_box(layout, "No current character!", width)
@@ -1406,16 +1409,23 @@ class CC3ToolsPipelinePanel(bpy.types.Panel):
             if not chr_cache or chr_cache.import_type != "fbx":
                 row.enabled = False
                 row2.enabled = False
-        elif chr_cache.rigified:
+        elif chr_cache and chr_cache.rigified:
             row = layout.row()
             row.scale_y = 2
             op = row.operator("cc3.exporter", icon="CUBE", text="Export To Unity")
             op.param = "EXPORT_UNITY"
-            row2 = layout.row()
-            row2.label(text="Rigged character FBX only", icon="INFO")
             if not chr_cache:
                 row.enabled = False
-                row2.enabled = False
+        row = layout.row()
+        row.prop(prefs, "export_animation_mode", expand=True)
+        if not chr_cache:
+            row.enabled = False
+        if chr_cache and chr_cache.rigified:
+            row = layout.row()
+            row.label(text="Rigged character FBX only", icon="INFO")
+            if not chr_cache:
+                row.enabled = False
+
 
         # export prefs
         box = layout.box()

--- a/panels.py
+++ b/panels.py
@@ -1142,6 +1142,7 @@ class CC3ToolsPhysicsPanel(bpy.types.Panel):
         prefs = bpy.context.preferences.addons[__name__.partition(".")[0]].preferences
         layout = self.layout
 
+        chr_cache = props.get_context_character_cache(context)
         missing_cloth = False
         has_cloth = False
         missing_coll = False
@@ -1152,7 +1153,7 @@ class CC3ToolsPhysicsPanel(bpy.types.Panel):
             if obj.type == "MESH":
                 meshes_selected += 1
                 clm = modifiers.get_cloth_physics_mod(obj)
-                com = modifiers.get_collision_physics_mod(obj)
+                com = modifiers.get_collision_physics_mod(chr_cache, obj)
                 if clm is None:
                     missing_cloth = True
                 else:

--- a/panels.py
+++ b/panels.py
@@ -1170,6 +1170,17 @@ class CC3ToolsPhysicsPanel(bpy.types.Panel):
         mat = utils.context_material(context)
         edit_mod, mix_mod = modifiers.get_material_weight_map_mods(obj, mat)
 
+        if chr_cache:
+            layout.box().label(text="Character Physics", icon="FORCE_CURVE")
+            if chr_cache.physics_applied:
+                layout.row().operator("cc3.setphysics", icon="REMOVE", text="Remove All Physics").param = "REMOVE_PHYSICS"
+            else:
+                layout.row().operator("cc3.setphysics", icon="ADD", text="Apply All Physics").param = "APPLY_PHYSICS"
+            if chr_cache.physics_disabled:
+                layout.row().operator("cc3.setphysics", icon="PLAY", text="Re-enable Physics").param = "ENABLE_PHYSICS"
+            else:
+                layout.row().operator("cc3.setphysics", icon="PAUSE", text="Disable Physics").param = "DISABLE_PHYSICS"
+
         box = layout.box()
         box.label(text="Create / Remove", icon="PHYSICS")
 
@@ -1308,13 +1319,6 @@ class CC3ToolsPhysicsPanel(bpy.types.Panel):
             op.param = "PHYSICS_SAVE"
             op = col_2.operator("cc3.setphysics", icon="ERROR", text="Delete")
             op.param = "PHYSICS_DELETE"
-
-        if chr_cache:
-            layout.box().label(text="Character Setting", icon="FORCE_CURVE")
-            if chr_cache.physics_disabled:
-                layout.row().operator("cc3.setphysics", icon="PLAY", text="Enable Physics").param = "ENABLE_PHYSICS"
-            else:
-                layout.row().operator("cc3.setphysics", icon="PAUSE", text="Disable Physics").param = "DISABLE_PHYSICS"
 
 
 class CC3ToolsPipelinePanel(bpy.types.Panel):

--- a/params.py
+++ b/params.py
@@ -929,7 +929,6 @@ SHADER_MATRIX = [
         # export variables to update json file on export that need special conversion
         # [json_id, default_value, function, prop_arg1, prop_arg2, prop_arg3...]
         "export": [
-            ["Custom/Iris UV Radius", 1.0, "func_export_iris_uv_radius", "eye_iris_scale", "eye_iris_radius"],
             ["Custom/Limbus Dark Scale", 6.5, "func_export_limbus_dark_scale", "eye_limbus_dark_radius"],
             ["Custom/Eye Corner Darkness Color", [255.0, 188.0, 179.0], "func_export_byte3", "eye_corner_shadow_color"],
             ["Custom/Iris Depth Scale", 0.3, "func_export_eye_depth", "eye_iris_depth"],

--- a/physics.py
+++ b/physics.py
@@ -37,7 +37,7 @@ def apply_cloth_settings(obj, cloth_type):
     mod.settings.time_scale = 1
     if cloth_type == "HAIR":
         mod.settings.quality = 4
-        mod.settings.pin_stiffness = 0.005
+        mod.settings.pin_stiffness = 0.01
         # physical properties
         mod.settings.mass = 0.05
         mod.settings.air_damping = 1
@@ -57,7 +57,7 @@ def apply_cloth_settings(obj, cloth_type):
         mod.collision_settings.collision_quality = 2
     elif cloth_type == "SILK":
         mod.settings.quality = 8
-        mod.settings.pin_stiffness = 0.01
+        mod.settings.pin_stiffness = 0.05
         # physical properties
         mod.settings.mass = 0.25
         mod.settings.air_damping = 1

--- a/preferences.py
+++ b/preferences.py
@@ -163,7 +163,12 @@ class CC3ToolsAddonPreferences(bpy.types.AddonPreferences):
     export_unity_mode: bpy.props.EnumProperty(items=[
                         ("BLEND","Blend File","Save the project as a blend file in a Unity project. All textures and folders will be copied to the new location and made relative to the blend file."),
                         ("FBX","FBX","Export the character as an .Fbx file to the specified location. All textures and folders will be copied."),
-                    ], default="BLEND", name = "Unity Export Mode")
+                    ], default="BLEND", name = "Unity Export")
+    export_animation_mode: bpy.props.EnumProperty(items=[
+                        ("ACTIONS","Actions", "Export all applicable actions with the character"),
+                        ("STRIPS","Strips", "Export only Unity actions via NLA strips"),
+                        ("BOTH","Both","Export both actions and NLA strips"),
+                    ], default="STRIPS", name = "Animation Export")
     export_texture_size: bpy.props.EnumProperty(items=vars.ENUM_TEX_LIST, default="2048", description="Size of procedurally generated textures to bake")
 
     physics_group: bpy.props.StringProperty(default="CC_Physics", name="Physics Vertex Group Prefix")

--- a/properties.py
+++ b/properties.py
@@ -1091,6 +1091,7 @@ class CC3CharacterCache(bpy.types.PropertyGroup):
 
     collision_body: bpy.props.PointerProperty(type=bpy.types.Object)
     physics_disabled: bpy.props.BoolProperty(default=False)
+    physics_applied: bpy.props.BoolProperty(default=False)
 
     rigified: bpy.props.BoolProperty(default=False)
     rigified_full_face_rig: bpy.props.BoolProperty(default=False)

--- a/properties.py
+++ b/properties.py
@@ -1090,6 +1090,7 @@ class CC3CharacterCache(bpy.types.PropertyGroup):
                     ], default="EEVEE", name = "Target Renderer")
 
     collision_body: bpy.props.PointerProperty(type=bpy.types.Object)
+    physics_disabled: bpy.props.BoolProperty(default=False)
 
     rigified: bpy.props.BoolProperty(default=False)
     rigified_full_face_rig: bpy.props.BoolProperty(default=False)
@@ -1208,15 +1209,21 @@ class CC3CharacterCache(bpy.types.PropertyGroup):
                 materials.append(cache.material)
         return materials
 
-    def get_all_objects(self, include_armature = True):
+    def get_all_objects(self, include_armature = True, include_children = False):
         objects = []
+        arm = None
         for cache in self.object_cache:
-            if utils.still_exists(cache.object):
-                if cache.object and cache.object.type == "ARMATURE":
+            if utils.still_exists(cache.object) and cache.object not in objects:
+                if cache.object.type == "ARMATURE":
+                    arm = cache.object
                     if include_armature:
                         objects.append(cache.object)
                 else:
                     objects.append(cache.object)
+        if include_children and arm:
+            for child in arm.children:
+                if child.type == "MESH" and child not in objects:
+                    objects.append(child)
         return objects
 
 

--- a/properties.py
+++ b/properties.py
@@ -1089,6 +1089,8 @@ class CC3CharacterCache(bpy.types.PropertyGroup):
                         ("CYCLES","Cycles","Build shaders for Cycles rendering."),
                     ], default="EEVEE", name = "Target Renderer")
 
+    collision_body: bpy.props.PointerProperty(type=bpy.types.Object)
+
     rigified: bpy.props.BoolProperty(default=False)
     rigified_full_face_rig: bpy.props.BoolProperty(default=False)
     rig_face_rig: bpy.props.BoolProperty(default=True)
@@ -1613,7 +1615,9 @@ class CC3ImportProps(bpy.types.PropertyGroup):
                     return chr_cache
         return None
 
-    def get_context_character_cache(self, context):
+    def get_context_character_cache(self, context = None):
+        if not context:
+            context = bpy.context
         obj = context.object
         mat = utils.context_material(context)
 

--- a/rigging.py
+++ b/rigging.py
@@ -1838,8 +1838,6 @@ def adv_bake_retarget_to_rigify(op, chr_cache):
 
     if retarget_rig:
         temp_collection = utils.force_visible_in_scene("TMP_Bake_Retarget", source_rig, retarget_rig, rigify_rig)
-        # turn off physics
-        physics.enable_disable_physics(chr_cache, False)
 
         # select just the retargeted bones in the rigify rig, to bake:
         if select_rig(rigify_rig):
@@ -1853,8 +1851,6 @@ def adv_bake_retarget_to_rigify(op, chr_cache):
             adv_retarget_remove_pair(op, chr_cache)
 
         utils.restore_visible_in_scene(temp_collection)
-        # turn on physics
-        physics.enable_disable_physics(chr_cache, True)
 
 
 def adv_bake_NLA_to_rigify(op, chr_cache):

--- a/rigging.py
+++ b/rigging.py
@@ -841,6 +841,9 @@ def reparent_to_rigify(self, chr_cache, cc3_rig, rigify_rig):
         for obj in cc3_rig.children:
             if obj.type == "MESH" and obj.parent == cc3_rig:
 
+                hidden = not obj.visible_get()
+                if hidden:
+                    obj.hide_set(False)
                 obj_cache = chr_cache.get_object_cache(obj)
 
                 if utils.try_select_object(obj, True) and utils.set_active_object(obj):
@@ -864,6 +867,9 @@ def reparent_to_rigify(self, chr_cache, cc3_rig, rigify_rig):
                     arm_mod : bpy.types.ArmatureModifier = modifiers.add_armature_modifier(obj, True)
                     if arm_mod:
                         arm_mod.object = rigify_rig
+
+                if hidden:
+                    obj.hide_set(True)
 
     utils.log_recess()
     return result

--- a/rigging.py
+++ b/rigging.py
@@ -305,7 +305,10 @@ def set_rigify_params(meta_rig):
             bone_value = params[2]
             pose_bone = bones.get_pose_bone(meta_rig, bone_name)
             if pose_bone:
-                exec(f"pose_bone.rigify_parameters.{bone_param} = bone_value", None, locals())
+                try:
+                    exec(f"pose_bone.rigify_parameters.{bone_param} = bone_value", None, locals())
+                except:
+                    pass
 
 
 def map_face_bones(cc3_rig, meta_rig, cc3_head_bone):

--- a/rigging.py
+++ b/rigging.py
@@ -301,10 +301,11 @@ def set_rigify_params(meta_rig):
     if select_rig(meta_rig):
         for params in rigify_mapping_data.RIGIFY_PARAMS:
             bone_name = params[0]
-            bone_rot_axis = params[1]
+            bone_param = params[1]
+            bone_value = params[2]
             pose_bone = bones.get_pose_bone(meta_rig, bone_name)
             if pose_bone:
-                pose_bone.rigify_parameters.rotation_axis = bone_rot_axis
+                exec(f"pose_bone.rigify_parameters.{bone_param} = bone_value", None, locals())
 
 
 def map_face_bones(cc3_rig, meta_rig, cc3_head_bone):

--- a/rigging.py
+++ b/rigging.py
@@ -1846,9 +1846,13 @@ def adv_bake_retarget_to_rigify(op, chr_cache):
                 if bone.name in rigify_mapping_data.RETARGET_RIGIFY_BONES:
                     bone.select = True
 
+            tmp_collection, layer_collections, to_hide = utils.scene_collection_only_items("TMP_BAKE", rigify_rig, source_rig, retarget_rig)
+
             bake_rig_animation(chr_cache, rigify_rig, source_action, None, True)
 
             adv_retarget_remove_pair(op, chr_cache)
+
+            utils.restore_scene_collection_only_items(tmp_collection, layer_collections, to_hide)
 
         utils.restore_visible_in_scene(temp_collection)
 
@@ -1878,7 +1882,13 @@ def adv_bake_NLA_to_rigify(op, chr_cache):
                     len(child.data.shape_keys.key_blocks) > 0):
                     shape_key_objects.append(child)
 
+        if not props.bake_nla_shape_keys:
+            tmp_collection, layer_collections, to_hide = utils.scene_collection_only_items("TMP_BAKE", rigify_rig)
+
         bake_rig_animation(chr_cache, rigify_rig, None, shape_key_objects, False, "NLA_Bake")
+
+        if not props.bake_nla_shape_keys:
+            utils.restore_scene_collection_only_items(tmp_collection, layer_collections, to_hide)
 
 
 # Shape-key retargeting
@@ -2213,8 +2223,12 @@ def adv_bake_rigify_to_unity(op, chr_cache):
                 for bone in export_rig.data.bones:
                     bone.select = True
 
+                tmp_collection, layer_collections, to_hide = utils.scene_collection_only_items("TMP_BAKE", rigify_rig)
+
                 # bake the action on the rigify rig into the export rig
                 bake_rig_animation(chr_cache, export_rig, action, None, True)
+
+                utils.restore_scene_collection_only_items(tmp_collection, layer_collections, to_hide)
 
             else:
                 op.report({'ERROR'}, "Unable to add copy constraints to Unity export rig!")
@@ -2257,8 +2271,12 @@ def adv_bake_rigify_NLA_to_unity(op, chr_cache):
                     if child.data.shape_keys and len(child.data.shape_keys) > 0:
                         shape_key_objects.append(child)
 
+            tmp_collection, layer_collections, to_hide = utils.scene_collection_only_items("TMP_BAKE", rigify_rig)
+
             # bake the action on the rigify rig into the export rig
             bake_rig_animation(chr_cache, export_rig, None, shape_key_objects, True, "NLA_Bake")
+
+            utils.restore_scene_collection_only_items(tmp_collection, layer_collections, to_hide)
 
         else:
             op.report({'ERROR'}, "Unable to add copy constraints to Unity export rig!")

--- a/rigify_mapping_data.py
+++ b/rigify_mapping_data.py
@@ -857,10 +857,20 @@ CONTROL_MODIFY = [
 
 
 RIGIFY_PARAMS = [
-    ["upper_arm.R", "x"],
-    ["upper_arm.L", "x"],
-    ["thigh.R", "x"],
-    ["thigh.L", "x"],
+    ["upper_arm.R", "rotation_axis", "x"],
+    ["upper_arm.L", "rotation_axis", "x"],
+    ["thigh.R", "rotation_axis", "x"],
+    ["thigh.L", "rotation_axis", "x"],
+
+    ["f_index.01.L", "primary_rotation_axis", "X"],
+    ["f_middle.01.L", "primary_rotation_axis", "X"],
+    ["f_ring.01.L", "primary_rotation_axis", "X"],
+    ["f_pinky.01.L", "primary_rotation_axis", "X"],
+
+    ["f_index.01.R", "primary_rotation_axis", "X"],
+    ["f_middle.01.R", "primary_rotation_axis", "X"],
+    ["f_ring.01.R", "primary_rotation_axis", "X"],
+    ["f_pinky.01.R", "primary_rotation_axis", "X"],
 ]
 
 

--- a/rigify_mapping_data.py
+++ b/rigify_mapping_data.py
@@ -826,7 +826,7 @@ UNITY_EXPORT_RIG = [
     ["DEF-eye.R", "DEF-spine.006", "CC_Base_R_Eye", "PLR"],
     ["DEF-eye.L", "DEF-spine.006", "CC_Base_L_Eye", "PLR"],
     # Jaw:
-    ["DEF-jaw", "DEF-spine.006", "CC_Base_JawRoot", "PLR"],
+    ["DEF-jaw", "DEF-spine.006", "CC_Base_JawRoot", "PLRT", "jaw_master"],
 ]
 
 

--- a/scene.py
+++ b/scene.py
@@ -155,7 +155,7 @@ def camera_setup(camera_loc, target_loc):
 def camera_auto_target(camera, target):
     props = bpy.context.scene.CC3ImportProps
 
-    chr_cache = props.get_context_character_cache(bpy.context)
+    chr_cache = props.get_context_character_cache()
     if chr_cache is None:
         chr_cache = props.get_character_cache(bpy.context.active_object, None)
     if chr_cache is None:

--- a/shaders.py
+++ b/shaders.py
@@ -335,9 +335,6 @@ def func_set_iris_tiling(v, w):
 def func_get_iris_scale(iris_uv_radius):
     return 0.16 / iris_uv_radius
 
-def func_export_iris_uv_radius(scale, radius):
-    return scale * radius
-
 def func_set_half(s):
     return s * 0.5
 

--- a/utils.py
+++ b/utils.py
@@ -971,3 +971,5 @@ def get_last_report():
     return lines[-1]
 
 
+def stop_now():
+    raise Exception("STOP!")

--- a/utils.py
+++ b/utils.py
@@ -201,6 +201,7 @@ def object_has_material(obj, name):
 
 
 def still_exists(obj):
+    """Test if obj still exists."""
     try:
         name = obj.name
         return True
@@ -209,21 +210,27 @@ def still_exists(obj):
 
 
 def object_exists_is_mesh(obj):
+    """Test if Object: obj still exists as an object in the scene, and is a mesh."""
     try:
+        name = obj.name
         return len(obj.users_scene) > 0 and obj.type == "MESH"
     except:
         return False
 
 
 def object_exists_is_armature(obj):
+    """Test if Object: obj still exists as an object in the scene, and is an armature."""
     try:
+        name = obj.name
         return len(obj.users_scene) > 0 and obj.type == "ARMATURE"
     except:
         return False
 
 
-def object_exists_in_scenes(obj):
+def object_exists(obj):
+    """Test if Object: obj still exists as an object in the scene."""
     try:
+        name = obj.name
         return len(obj.users_scene) > 0
     except:
         return False

--- a/utils.py
+++ b/utils.py
@@ -434,13 +434,18 @@ def get_active_view_layer_object():
     return bpy.context.view_layer.objects.active
 
 
-def set_active_object(obj):
+def set_active_object(obj, deselect_all = False):
     try:
+        if deselect_all:
+            bpy.ops.object.select_all(action='DESELECT')
         obj.select_set(True)
         bpy.context.view_layer.objects.active = obj
         return (bpy.context.active_object == obj)
     except:
         return False
+
+def set_only_active_object(obj):
+    return set_active_object(obj, True)
 
 
 def set_mode(mode):

--- a/utils.py
+++ b/utils.py
@@ -694,7 +694,7 @@ def get_context_area(context, area_type):
 
 
 # C.scene.view_layers[0].layer_collection.children[0].exclude
-def scene_collection_only_items(collection_name, *items):
+def limit_view_layer_to_collection(collection_name, *items):
     layer_collections = []
     to_hide = []
     # exclude all active layer collections
@@ -711,12 +711,19 @@ def scene_collection_only_items(collection_name, *items):
     tmp_collection = bpy.data.collections.new(collection_name)
     bpy.context.scene.collection.children.link(tmp_collection)
     for item in items:
-        tmp_collection.objects.link(item)
+        if item:
+            if type(item) is list:
+                for sub_item in item:
+                    tmp_collection.objects.link(sub_item)
+                    sub_item.hide_set(False)
+            else:
+                tmp_collection.objects.link(item)
+                item.hide_set(False)
     # return the temp collection and the layers exlcuded
     return tmp_collection, layer_collections, to_hide
 
 
-def restore_scene_collection_only_items(tmp_collection, layer_collections, to_hide):
+def restore_limited_view_layers(tmp_collection, layer_collections, to_hide):
     objects = []
     for obj in tmp_collection.objects:
         objects.append(obj)


### PR DESCRIPTION
### 1.3.6
- Rigify
    - Finger roll alignment fixed. All fingers now have exactly the same local bend axis.
    - Disables all physics modifiers non-contributing armatures and meshes during retarget baking to speed it up a bit.
- Physics:
    - Low poly (1/8th) Collision Body mesh created from decimating a copy of the Body mesh and removing the eyelashes.
        - Hair would easily get trapped in the eyelashes and a lower poly collision mesh should speed up the cloth simulation.
    - PhysX weight maps normalized, provides a more consistent and controllable simulation across different weight maps.
    - Tweaked some cloth simulation parameters.
    - Smart Hair meshes in particular should simulate better now.
- Unity:
    - Added animation export options (Actions or Strips)