### PR TITLE
Skip reassigning rig on export cleanup for objects without armature.

### DIFF
--- a/rigging.py
+++ b/rigging.py
@@ -2966,6 +2966,10 @@ def finish_rigify_export(chr_cache, export_rig, export_actions, vertex_group_map
             continue
         child.parent = rigify_rig
         mod = modifiers.get_object_modifier(child, "ARMATURE")
+
+        if not mod:
+            continue
+        
         mod.object = rigify_rig
         restore_from_unity_vertex_groups(child, vertex_group_map)
 


### PR DESCRIPTION
Closes #178 

This shouldn't break anything and skips two tasks:
1. Reassigning rig - but if there is no armature it saves it from crashing.
2. `restore_from_unity_vertex_groups()` but `rename_vertex_groups()` already has similar guard so it's not necessary to restore anything.