### PR TITLE
Fix eye_occlusion_displace range

### DIFF
--- a/params.py
+++ b/params.py
@@ -344,7 +344,7 @@ SHADER_MATRIX = [
         # [json_id, default_value, function, prop_arg1, prop_arg2, prop_arg3...]
         "export": [
             ["Custom/Shadow Color", [255.0, 255.0, 255.0], "func_export_byte3_linear", "eye_occlusion_color"],
-            ["Custom/Depth Offset", 0.02, "func_mul_100", "eye_occlusion_displace"],
+            ["Custom/Depth Offset", 0.02, "", "eye_occlusion_displace"],
         ],
         "ui": [
             # ["HEADER", label, icon]
@@ -529,7 +529,7 @@ SHADER_MATRIX = [
         "export": [
             ["Custom/Shadow Color", [255.0, 255.0, 255.0], "func_export_byte3_linear", "eye_occlusion_color"],
             ["Custom/Blur Color", [255.0, 255.0, 255.0], "func_export_byte3_linear", "eye_occlusion_blur_color"],
-            ["Custom/Depth Offset", 0.02, "func_mul_100", "eye_occlusion_displace"],
+            ["Custom/Depth Offset", 0.02, "", "eye_occlusion_displace"],
         ],
         "ui": [
             # ["HEADER", label, icon]
@@ -2405,4 +2405,5 @@ JSON_PHYSICS_MATERIAL = {
     "Self Collision": False,
     "Self Collision Margin": 0.0,
     "Stiffness Frequency": 10.0
+
 }


### PR DESCRIPTION
Hi, the unity shader graph expects Eye Occlusion Displace values from interval (-1, 1). In Blender, the value is set to 0.5 by default (from the CC5 Blender Pipeline export) and when exporting, it is multiplied by 100 resulting in a value of 50. This value than has to be re-initialized each time a character is imported into unity. I did not figure out the reason for the division and multiplication, but the removal solves the problem for us. Thanks for looking into it.